### PR TITLE
Force messageID to be 32 characters long

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -160,7 +160,7 @@ final class Client
                 'gatewayUrl' => $gatewayUrl,
                 'paywayList' => [
                     'serviceID' => $this->configuration->getServiceId(),
-                    'messageID' => bin2hex(random_bytes(ClientEnum::MESSAGE_ID_LENGTH))
+                    'messageID' => bin2hex(random_bytes(ClientEnum::MESSAGE_ID_LENGTH / 2))
                 ]
             ],
             PaywayListDto::class,


### PR DESCRIPTION
bin2hex() doubles number of characters. That's why random_bytes should generate half of ClientEnum::MESSAGE_ID_LENGTH bytes